### PR TITLE
[BUGFIX] Fix two typos

### DIFF
--- a/manuscript/howforfriends.md
+++ b/manuscript/howforfriends.md
@@ -74,7 +74,7 @@ For most software projects communication is vital. I'd say _all_ software projec
 
 Different communication styles fit different parts of the project. While face-to-face meetings might work best to eke requirements out of clients, instant messaging often works best for software teams to avoid interrupting one another.
 
-Having just the right amount of communication so things run smoothly and developers still have enough time to work is an art that takes most people a few years to develop. Some never get there and the internet is full of programmers complaining about cow-orkers and pointy-haired bosses.
+Having just the right amount of communication so things run smoothly and developers still have enough time to work is an art that takes most people a few years to develop. Some never get there and the internet is full of programmers complaining about co-workers and pointy-haired bosses.
 
 Programmers hate meetings and with good reason.
 

--- a/manuscript/sleep-science.md
+++ b/manuscript/sleep-science.md
@@ -15,7 +15,7 @@ You still need to sleep, though. What happens when you go to bed at two in the m
 
 Come evening, you don't feel sleepy until midnight. You're just working on something interesting, so you keep working until 1am. Or slightly later.
 
-Eventually your sleep cycle shifts into a different timezone because you keep goign to bed later and later, because you've woken up much later and so on ad infinitum until your alarm clock and society pressure put you in an equilibrium of sorts.
+Eventually your sleep cycle shifts into a different timezone because you keep going to bed later and later, because you've woken up much later and so on ad infinitum until your alarm clock and society pressure put you in an equilibrium of sorts.
 
 For a lot of people that equilibrium seems to be waking up at 11am and going to bed at 3am. I don't know why.
 


### PR DESCRIPTION
During reading, i`ve found two typos.
In this commit this typos will be fixed:
- `goign` => `going`
- `cow-orkers`=> `co-workers`

Great book. THX!
